### PR TITLE
Add global fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,10 @@ module.exports = function getAvatar(sbot, source, dest, cb) {
       }),
     ]),
     pull.filter(function (msg) {
-      return msg && msg.value.content && (!name || !image)
+      return msg && msg.value.content
     }),
     pull.drain(function (msg) {
+      if (name && image) return false // end the streams early
       var c = msg.value.content
       if (!name) {
         name = c.name
@@ -49,7 +50,7 @@ module.exports = function getAvatar(sbot, source, dest, cb) {
         image = imgLink && imgLink.link
       }
     }, function (err) {
-      if (err) return cb (err)
+      if (err && err !== true) return cb (err)
       if (!name) name = truncate(dest, 8)
       cb(null, {id: dest, name: name, image: image, from: source})
     })

--- a/index.js
+++ b/index.js
@@ -28,6 +28,13 @@ module.exports = function getAvatar(sbot, source, dest, cb) {
         values: true,
         reverse: true
       }),
+      // Finally, get About info from other feeds.
+      sbot.links({
+        dest: dest,
+        rel: 'about',
+        values: true,
+        reverse: true
+      }),
     ]),
     pull.filter(function (msg) {
       return msg && msg.value.content && (!name || !image)


### PR DESCRIPTION
Currently we look for About data from the source and then from the dest. This PR adds a fallback to get About data any feed if the source and dest both don't have enough. This means uxers can benefit from other uxers naming things other than their own things.

Also I add an optimization to abort reading the links streams when enough data is obtained from them.
