### PR TITLE
Let messages name themselves

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "pull-cat": "^1.1.9",
     "pull-stream": "^3.4.3",
-    "ssb-msgs": "^5.2.0"
+    "ssb-msgs": "^5.2.0",
+    "ssb-ref": "^2.3.2"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This adds an additional fallback source of About info, which is the message itself, when the target is a message id.

This is used in git-ssb to let a repo be created and named in the same message, by including the name in the repo root message.
