### PR TITLE
update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "ssb-avatar",
   "description": "",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/dominictarr/ssb-avatar",
   "repository": {
     "type": "git",
     "url": "git://github.com/dominictarr/ssb-avatar.git"
   },
   "dependencies": {
-    "pull-cat": "^1.1.9",
-    "pull-stream": "^3.4.3",
+    "pull-cat": "^1.1.11",
+    "pull-stream": "^3.6.1",
     "ssb-msgs": "^5.2.0",
-    "ssb-ref": "^2.3.2"
+    "ssb-ref": "^2.7.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
I was messing around with starboard, and it was throwing this error:

```
/home/ev/starboard/node_modules/pull-cat/index.js:28
        streams[0](null, function (err, data) {
                  ^

TypeError: streams[0] is not a function
    at next (/home/ev/starboard/node_modules/pull-cat/index.js:28:19)
    at /home/ev/starboard/node_modules/pull-cat/index.js:37:7
    at next (/home/ev/starboard/node_modules/pull-stream/throughs/filter.js:14:9)
    at next (/home/ev/starboard/node_modules/pull-stream/sinks/drain.js:16:11)
    at sink (/home/ev/starboard/node_modules/pull-stream/sinks/drain.js:37:9)
    at pull (/home/ev/starboard/node_modules/pull-stream/pull.js:41:14)
    at getAvatar (/home/ev/starboard/node_modules/ssb-avatar/index.js:14:3)
    at getAvatar (/home/ev/starboard/x.js:20:6)
    at /home/ev/starboard/node_modules/pull-paramap/index.js:41:11
    at PacketStreamSubstream.weird.read (/home/ev/starboard/node_modules/muxrpc/pull-weird.js:33:7)
```

Updating `pull-cat` in `ssb-avatar` fixed the issue. 

I went ahead and updates all of the other dependencies too.